### PR TITLE
Guard against setting html of the editor to null

### DIFF
--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -568,7 +568,9 @@ export default Ember.Component.extend({
     // Properly update the editors html,
     // depending on the current state
     if ( this.get('_editorInitialized') ) {
-      this._editor.html.set( this.get('_content') );
+      if ( this.get('hasContent') ) {
+        this._editor.html.set( this.get('_content') );
+      }
     } else if ( this.get('_editorInitializing') ) {
       this.set( '_shouldSetHtml', true );
     } else {


### PR DESCRIPTION
When the html set on the editor is null, froala-editor throws an exception. 

I was unable to recreate this problem in a test, but it happens in my app when the model field I'm using for the editor is cleared. 