### PR TITLE
Set defaultContent to be an empty string

### DIFF
--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -28,7 +28,7 @@ export default Ember.Component.extend({
   // If there is no 'content' present then this is the
   // default content used when creating the editor
   // Note: This is the standard, "blank" Froala Editor content
-  defaultContent: '<p><br></p>',
+  defaultContent: '',
 
 
 


### PR DESCRIPTION
Following discussion in froala/wysiwyg-editor#1275, `defaultContent` should be an empty string.