### PR TITLE
Add Ember 2.8 Support

### DIFF
--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import layout from '../templates/components/froala-editor';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 
 export default Ember.Component.extend({
@@ -54,7 +55,7 @@ export default Ember.Component.extend({
   // Mainly an internal Computed Property to determine if the
   // current 'content' is actually a SafeString object
   isSafeString: Ember.computed('content', function(){
-    return this.get('content') instanceof Ember.Handlebars.SafeString;
+    return isHTMLSafe(this.get('content'));
   }),
 
 
@@ -209,10 +210,10 @@ export default Ember.Component.extend({
 
 
     // Convert SafeStrings to actual strings
-    if ( oldContent instanceof Ember.Handlebars.SafeString ) {
+    if ( isHTMLSafe(oldContent) ) {
       oldContent = oldContent.toString();
     }
-    if ( newContent instanceof Ember.Handlebars.SafeString ) {
+    if ( isHTMLSafe(newContent) ) {
       newContent = newContent.toString();
     }
 

--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -172,6 +172,7 @@ export default Ember.Component.extend({
     this.set( '_isSettingContent'  , false ); // No public API, internal state only
     this.set( '_shouldReinitEditor', false ); // No public API, internal state only
     this.set( '_shouldSetHtml'     , false ); // No public API, internal state only
+    this._oldContent = this.get( 'content' ); // No public API, internal state only
   }, // init()
 
 
@@ -202,11 +203,11 @@ export default Ember.Component.extend({
 
 
   // Trigger the proper "observer" when its related attribute value has changed
-  didUpdateAttrs({ oldAttrs, newAttrs }) {
+  didUpdateAttrs() {
 
-    // Get the values directly from the attrs
-    let oldContent = this.getAttrFor( oldAttrs, 'content' );
-    let newContent = this.getAttrFor( newAttrs, 'content' );
+    // Get the old and new values
+    let oldContent = this._oldContent;
+    let newContent = this.get( 'content' );
 
 
     // Convert SafeStrings to actual strings
@@ -226,6 +227,10 @@ export default Ember.Component.extend({
     } else {
       this.optionsDidChange();
     }
+
+
+    // Update _oldContent
+    this._oldContent = newContent;
 
   }, // didUpdateAttrs()
 

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "ember-try": "^0.2.2",
     "liquid-fire": "0.23.0",
     "loader.js": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1",
     "ember-try": "^0.2.2",
     "liquid-fire": "0.23.0",
     "loader.js": "^4.0.1"
@@ -79,6 +78,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
+    "ember-string-ishtmlsafe-polyfill": "^1.0.1",
     "object-assign": "^4.0.1",
     "rsvp": "^3.2.1"
   },

--- a/tests/integration/components/froala-editor-test.js
+++ b/tests/integration/components/froala-editor-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 moduleForComponent('froala-editor', 'Integration | Component | froala editor', {
   integration: true
@@ -47,7 +48,7 @@ test('content attribute is set as editor content', function(assert) {
 test('SafeString in, SafeString out (via *-getHtml event handler)', function(assert) {
 
   this.set('runAsserts', html => {
-    assert.ok(html instanceof Ember.Handlebars.SafeString);
+    assert.ok(isHTMLSafe(html));
   });
 
   this.set('safestring', Ember.String.htmlSafe('<p>This is safe!</p>'));


### PR DESCRIPTION
This PR adds support for Ember v2.8.0 and also resolves a deprecation warning that was introduced by Ember v2.8.0.

As well as refactoring away from using the private `getAttrFor` method, this PR also refactors away from using the arguments supplied to the `didUpdateAttrs` method as I believe that there is a possibility of these being deprecated in a future version of Ember.js.