### PR TITLE
Update repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "ember try:testall",
     "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push; git checkout -"
   },
-  "repository": "froala/ember-froala-editor",
+  "repository": "https://github.com/froala/ember-froala-editor.git",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This should allow [emberobserver.com](https://emberobserver.com) to score the add-on correctly.

Link: https://emberobserver.com/addons/ember-froala-editor