### PR TITLE
Re-attach event listeners when re-initializing the editor

### DIFF
--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -310,6 +310,7 @@ const FroalaEditorComponent = Ember.Component.extend({
   // Note: This is mainly for the optionsDidChange() handler
   reinitEditor() {
     this.destroyEditor();
+    this.attachEventListeners();
     this.initEditor();
   }, // reinitEditor()
 


### PR DESCRIPTION
We tried our best to avoid changing options on an already-rendered editor but in the end it proved unavoidable. This fixes a problem where event listeners were never reattached. Thanks! 😄 