### PR TITLE
Fix `TypeError: propertyName.indexOf is not a function` error

### DIFF
--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -66,9 +66,7 @@ export default class FroalaEditorComponent extends Component {
     // Class methods are not available in a `for (name in this)` loop
     let propertyNames = Object.getOwnPropertyNames(this.__proto__);
 
-    for (let i in propertyNames) {
-      let propertyName = propertyNames[i];
-
+    for (let propertyName of propertyNames) {
       // Only names that start with on- are callbacks
       if (propertyName.indexOf('on-') !== 0) {
         continue;


### PR DESCRIPTION
If `propertyNames` is enumerated with the `for ... in` syntax, `"_super"` is included as an index, so `propertyName` will become a function object unintentionally and an error will occur.