### PR TITLE
Fix: added typeof operator to bind and fire user's init callback

### DIFF
--- a/addon/components/froala-editor.js
+++ b/addon/components/froala-editor.js
@@ -266,7 +266,7 @@ export default class FroalaEditorComponent extends Component {
 
     // Since we overrode this event callback,
     // call the passed in callback(s) if there are any
-    if (initEventCallback === 'function') {
+    if (typeof initEventCallback === 'function') {
       // Mimic default behavior by binding the editor instance to the called context
       initEventCallback.bind(editor)(...args);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-froala-editor",
-  "version": "4.0.14",
+  "version": "4.0.13",
   "description": "An ember-cli addon that properly wraps the Froala WYSIWYG Editor for use in Ember.js",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-froala-editor",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "description": "An ember-cli addon that properly wraps the Froala WYSIWYG Editor for use in Ember.js",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
This PR is related to the issue [#120](https://github.com/froala/ember-froala-editor/issues/120)

Added `typeof` operator in file `frontend/node_modules/ember-froala-editor/addon/components/froala-editor.js` inside `setupEditor` action to make the condition satisfy to bind the users init callback with editor instance and fire it.